### PR TITLE
Use URIResolver when loading XSLT source

### DIFF
--- a/src/java/org/apache/fop/cli/InputHandler.java
+++ b/src/java/org/apache/fop/cli/InputHandler.java
@@ -257,6 +257,10 @@ public class InputHandler implements ErrorListener, Renderable {
         try {
             // Setup XSLT
             TransformerFactory factory = TransformerFactory.newInstance();
+            if (uriResolver != null) {
+                factory.setURIResolver(uriResolver);
+            }
+            factory.setErrorListener(this);
             Transformer transformer;
 
             Source xsltSource = createXSLTSource();
@@ -271,9 +275,6 @@ public class InputHandler implements ErrorListener, Renderable {
                         transformer.setParameter((String) xsltParams.elementAt(i),
                             (String) xsltParams.elementAt(i + 1));
                     }
-                }
-                if (uriResolver != null) {
-                    transformer.setURIResolver(uriResolver);
                 }
             }
             transformer.setErrorListener(this);


### PR DESCRIPTION
The XSL processor attempts to reach out to the internet to resolve URIs in XSLT source files. This happens because the URIResolver is not registered on the TransformerFactory when it creates a Transformer instance for a given XSLT source.

This fix assigns the URIResolver to the TransformerFactory (which then gets assigned to any Transformer created from that factory) rather than on the Transformer. This change allows the processor to resolve URIs in the XSLT source when the source is being loaded.

This patch also registers the InputHandler as an ErrorListener for the TransformerFactory so that any errors that occur while loading the XSLT are logged consistently.
