### PR TITLE
Add methods ‘setPageWidth’ and ‘setPageHeight’ to class FOUserAgent.

### DIFF
--- a/src/java/org/apache/fop/apps/FOUserAgent.java
+++ b/src/java/org/apache/fop/apps/FOUserAgent.java
@@ -106,6 +106,8 @@ public class FOUserAgent {
     private EventBroadcaster eventBroadcaster = new FOPEventBroadcaster();
     private StructureTreeEventHandler structureTreeEventHandler
             = DummyStructureTreeEventHandler.INSTANCE;
+    private String pageWidth;
+    private String pageHeight;
 
     /** Producer:  Metadata element for the system/software that produces
      * the document. (Some renderers can store this in the document.)
@@ -142,6 +144,8 @@ public class FOUserAgent {
      */
     FOUserAgent(final FopFactory factory, InternalResourceResolver resourceResolver) {
         this.factory = factory;
+        pageWidth = factory.getPageWidth();
+        pageHeight = factory.getPageHeight();
         this.resourceResolver = resourceResolver;
         setTargetResolution(factory.getTargetResolution());
         setAccessibility(factory.isAccessibilityEnabled());
@@ -504,9 +508,21 @@ public class FOUserAgent {
      *
      * @return the page-height, as a String
      * @see FopFactory#getPageHeight()
+     * @see #setPageHeight
      */
     public String getPageHeight() {
-        return factory.getPageHeight();
+        return pageHeight;
+    }
+
+    /**
+     * Sets the default page-height to use as fallback,
+     * in case page-height="auto"
+     *
+     * @param pageHeight the new page-height, as a String
+     * @see #getPageHeight
+     */
+    public void setPageHeight(String pageHeight) {
+        this.pageHeight = pageHeight;
     }
 
     /**
@@ -515,9 +531,21 @@ public class FOUserAgent {
      *
      * @return the page-width, as a String
      * @see FopFactory#getPageWidth()
+     * @see #setPageWidth
      */
     public String getPageWidth() {
-        return factory.getPageWidth();
+        return pageWidth;
+    }
+
+    /**
+     * Sets the default page-width to use as fallback,
+     * in case page-width="auto"
+     *
+     * @param pageWidth the page-width, as a String
+     * @see #getPageWidth
+     */
+    public void setPageWidth(String pageWidth) {
+        this.pageWidth = pageWidth;
     }
 
     /**


### PR DESCRIPTION
It used to be possible to provide default page dimensions on a per-UA basis. This was useful because the needed page dimensions may change for different runs (i.e. `Fop` instances) in the same application (i.e. same `FopFactory` instance). An application I am currently shipping needs this: the page dimensions are set to whatever the user previously entered in the Page Setup dialog.

In FOP 2.0, however, this is no longer possible, because there is no `public` or `protected` constructor to the `FOUserAgent` class. Hence, there is no way to override the `getPageWidth` and `getPageHeight` methods.

This PR serves the aforementioned use case by adding `setPageWidth` and `setPageHeight` methods to the `FOUserAgent` class.
