### PR TITLE
Change the method modifier "build" to "getParams".

### DIFF
--- a/fop-events/src/main/java/org/apache/fop/events/Event.java
+++ b/fop-events/src/main/java/org/apache/fop/events/Event.java
@@ -182,6 +182,15 @@ public class Event extends EventObject {
          * Returns the accumulated parameter map.
          * @return the accumulated parameter map
          */
+        public Map<String, Object> getParams() {
+            return this.params;
+        }
+        
+        /**
+         * Returns the accumulated parameter map.
+         * @return the accumulated parameter map
+         */
+        @Deprecated
         public Map<String, Object> build() {
             return this.params;
         }


### PR DESCRIPTION
The method just returns one field "params" of the current class, thus method name "getParams" should be better than "build".