### PR TITLE
[FOP-2815] Replace SimpleLog with LogFactory

### DIFF
--- a/fop-core/src/main/java/org/apache/fop/svg/AbstractFOPTranscoder.java
+++ b/fop-core/src/main/java/org/apache/fop/svg/AbstractFOPTranscoder.java
@@ -21,10 +21,13 @@ package org.apache.fop.svg;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
 
+import org.apache.commons.logging.LogFactory;
 import org.w3c.dom.DOMImplementation;
 import org.xml.sax.EntityResolver;
 
@@ -171,13 +174,13 @@ public abstract class AbstractFOPTranscoder extends SVGAbstractTranscoder implem
 
     /**
      * Returns the logger associated with this transcoder. It returns a
-     * SimpleLog if no logger has been explicitly set.
+     * LogFactory if no logger has been explicitly set.
      * @return Logger the logger for the transcoder.
      */
     protected final Log getLogger() {
         if (this.logger == null) {
-            this.logger = new SimpleLog("FOP/Transcoder");
-            ((SimpleLog) logger).setLevel(SimpleLog.LOG_LEVEL_INFO);
+            this.logger = LogFactory.getLog("FOP/Transcoder");
+            ((Logger) logger).setLevel(Level.INFO);
         }
         return this.logger;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.apache.xmlgraphics</groupId>
   <artifactId>fop-parent</artifactId>
-  <version>2.4.0-SNAPSHOT</version>
+  <version>2.4.1-SNAPSHOT</version>
   <name>Apache FOP Parent</name>
   <description>XML Graphics Format Object Processor</description>
   <packaging>pom</packaging>


### PR DESCRIPTION
References https://issues.apache.org/jira/browse/FOP-2815.

* Replaces deprecated SimpleLog with LogFactory. The LogFactory gets set when the logger is null.  The logging level is also set to INFO (value: 800).
* Bumped the parent pom to 2.4.1-SNAPSHOT.